### PR TITLE
Fix SVG warning 'XML tag has empty body'

### DIFF
--- a/demos/03-tutorial-application-features/level-of-detail-style/index.html
+++ b/demos/03-tutorial-application-features/level-of-detail-style/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Level of Details - Application Features Tutorial [yFiles for HTML]</title>
@@ -68,18 +68,18 @@
 
     <defs>
       <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient">
-        <stop stop-color="#CCFFFF" stop-opacity="1" offset="0"></stop>
-        <stop stop-color="#249AE7" stop-opacity="1" offset="1"></stop>
+        <stop stop-color="#CCFFFF" stop-opacity="1" offset="0"/>
+        <stop stop-color="#249AE7" stop-opacity="1" offset="1"/>
       </linearGradient>
 
       <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient_focused">
-        <stop stop-color="#FFFFFF" stop-opacity="1" offset="0"></stop>
-        <stop stop-color="#FFA500" stop-opacity="1" offset="1"></stop>
+        <stop stop-color="#FFFFFF" stop-opacity="1" offset="0"/>
+        <stop stop-color="#FFA500" stop-opacity="1" offset="1"/>
       </linearGradient>
 
       <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient_hover">
-        <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="0"></stop>
-        <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="1"></stop>
+        <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="0"/>
+        <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="1"/>
       </linearGradient>
     </defs>
 
@@ -91,18 +91,18 @@
       <use xlink:href="{Binding status"/>
 
       <g class="hoverable">
-        <rect width="3" height="100"></rect>
-        <rect width="3" height="100" transform="translate(282 0)"></rect>
-        <rect width="285" height="3"></rect>
-        <rect width="285" height="3" transform="translate(0 97)"></rect>
+        <rect width="3" height="100"/>
+        <rect width="3" height="100" transform="translate(282 0)"/>
+        <rect width="285" height="3"/>
+        <rect width="285" height="3" transform="translate(0 97)"/>
       </g>
       <g style="font-size:10px; font-family:Roboto,sans-serif; font-weight: 300; fill: #444">
-        <text transform="translate(10 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"></text>
+        <text transform="translate(10 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"/>
         <text transform="translate(10 45)" data-content="{Binding position}"
-          style="text-transform: uppercase; font-weight: 400"></text>
-        <text transform="translate(10 72)" data-content="{Binding email}"></text>
-        <text transform="translate(10 88)" data-content="{Binding phone}"></text>
-        <text transform="translate(70 88)" data-content="{Binding fax}"></text>
+          style="text-transform: uppercase; font-weight: 400"/>
+        <text transform="translate(10 72)" data-content="{Binding email}"/>
+        <text transform="translate(10 88)" data-content="{Binding phone}"/>
+        <text transform="translate(70 88)" data-content="{Binding fax}"/>
       </g>
     </g>
     <g id="intermediateNodeStyleTemplate">
@@ -110,16 +110,16 @@
       <rect fill="#FFFFFF" stroke="#C0C0C0" width="285" height="100"/>
       <use xlink:href="{Binding status}"/>
       <g class="hoverable">
-        <rect width="3" height="100"></rect>
-        <rect width="3" height="100" transform="translate(282 0)"></rect>
-        <rect width="285" height="3"></rect>
-        <rect width="285" height="3" transform="translate(0 97)"></rect>
+        <rect width="3" height="100"/>
+        <rect width="3" height="100" transform="translate(282 0)"/>
+        <rect width="285" height="3"/>
+        <rect width="285" height="3" transform="translate(0 97)"/>
       </g>
 
       <text transform="translate(10 40)" data-content="{Binding name}"
-        style="font-size:26px; font-family:Roboto,sans-serif; fill:#336699;"></text>
+        style="font-size:26px; font-family:Roboto,sans-serif; fill:#336699;"/>
       <text transform="translate(10 70)" data-content="{Binding position}"
-        style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"></text>
+        style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"/>
 
     </g>
     <g id="overviewNodeStyleTemplate">
@@ -127,13 +127,13 @@
       <rect fill="#FFFFFF" width="285" height="100"/>
       <use xlink:href="{Binding status}"/>
       <g class="hoverable">
-        <rect width="3" height="100"></rect>
-        <rect width="3" height="100" transform="translate(282 0)"></rect>
-        <rect width="285" height="3"></rect>
-        <rect width="285" height="3" transform="translate(0 97)"></rect>
+        <rect width="3" height="100"/>
+        <rect width="3" height="100" transform="translate(282 0)"/>
+        <rect width="285" height="3"/>
+        <rect width="285" height="3" transform="translate(0 97)"/>
       </g>
       <text transform="translate(10 50)" data-content="{Binding name}"
-        style="font-size:40px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"></text>
+        style="font-size:40px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"/>
     </g>
   </script>
 </head>

--- a/demos/complete/collapse/index.html
+++ b/demos/complete/collapse/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Collapsible Tree Demo [yFiles for HTML]</title>
@@ -80,12 +80,12 @@
     </defs>
     <g id="InnerNodeStyleTemplate">
       <rect stroke="none" fill="{TemplateBinding styleTag, Converter=collapseDemo.backgroundConverter}" rx="4" ry="4"
-            width="60" height="30"></rect>
-      <use xlink:href="{TemplateBinding styleTag, Converter=collapseDemo.iconConverter}" style="pointer-events:none"></use>
+            width="60" height="30"/>
+      <use xlink:href="{TemplateBinding styleTag, Converter=collapseDemo.iconConverter}" style="pointer-events:none"/>
     </g>
     <g id="LeafNodeStyleTemplate">
       <rect stroke="none" fill="#81E368" rx="4" ry="4" width="58" height="28"
-            transform="translate(1 1)"></rect>
+            transform="translate(1 1)"/>
     </g>
   </script>
 </head>

--- a/demos/complete/orgchartviewer/index.html
+++ b/demos/complete/orgchartviewer/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title id="title">Organization Chart Viewer Demo [yFiles for HTML]</title>
@@ -65,18 +65,18 @@
 
 <defs>
 <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient">
-  <stop stop-color="#CCFFFF" stop-opacity="1" offset="0"></stop>
-  <stop stop-color="#249AE7" stop-opacity="1" offset="1"></stop>
+  <stop stop-color="#CCFFFF" stop-opacity="1" offset="0"/>
+  <stop stop-color="#249AE7" stop-opacity="1" offset="1"/>
 </linearGradient>
 
 <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient_focused">
-  <stop stop-color="#FFFFFF" stop-opacity="1" offset="0"></stop>
-  <stop stop-color="#FFA500" stop-opacity="1" offset="1"></stop>
+  <stop stop-color="#FFFFFF" stop-opacity="1" offset="0"/>
+  <stop stop-color="#FFA500" stop-opacity="1" offset="1"/>
 </linearGradient>
 
 <linearGradient x1="0.5" y1="0" x2="0.5" y2="1" spreadMethod="pad" id="background_gradient_hover">
-  <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="0"></stop>
-  <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="1"></stop>
+  <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="0"/>
+  <stop stop-color="#FFFFFF" stop-opacity="0.6" offset="1"/>
 </linearGradient>
 </defs>
 
@@ -87,18 +87,18 @@
   <use xlink:href="{Binding status, Converter=orgChartConverters.addHashConverter}"/>
   <use xlink:href="{Binding status, Converter=orgChartConverters.addHashConverter, Parameter=_icon}" transform="translate(26 84)"/>
   <g class="hoverable">
-    <rect width="3" height="100"></rect>
-    <rect width="3" height="100" transform="translate(282 0)"></rect>
-    <rect width="285" height="3"></rect>
-    <rect width="285" height="3" transform="translate(0 97)"></rect>
+    <rect width="3" height="100"/>
+    <rect width="3" height="100" transform="translate(282 0)"/>
+    <rect width="285" height="3"/>
+    <rect width="285" height="3" transform="translate(0 97)"/>
   </g>
   <g style="font-size:10px; font-family:Roboto,sans-serif; font-weight: 300; fill: #444">
-    <text transform="translate(100 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"></text>
-    <text transform="translate(100 45)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=true}" style="text-transform: uppercase; font-weight: 400"></text>
-    <text transform="translate(100 57)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=false}" style="text-transform: uppercase; font-weight: 400"></text>
-    <text transform="translate(100 72)" data-content="{Binding email}"></text>
-    <text transform="translate(100 88)" data-content="{Binding phone}"></text>
-    <text transform="translate(170 88)" data-content="{Binding fax}"></text>
+    <text transform="translate(100 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"/>
+    <text transform="translate(100 45)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=true}" style="text-transform: uppercase; font-weight: 400"/>
+    <text transform="translate(100 57)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=false}" style="text-transform: uppercase; font-weight: 400"/>
+    <text transform="translate(100 72)" data-content="{Binding email}"/>
+    <text transform="translate(100 88)" data-content="{Binding phone}"/>
+    <text transform="translate(170 88)" data-content="{Binding fax}"/>
   </g>
 </g>
 <g id="intermediateNodeStyleTemplate">
@@ -106,28 +106,28 @@
   <rect fill="#FFFFFF" stroke="#C0C0C0" width="285" height="100"/>
   <use xlink:href="{Binding status, Converter=orgChartConverters.addHashConverter}"/>
   <g class="hoverable">
-    <rect width="3" height="100"></rect>
-    <rect width="3" height="100" transform="translate(282 0)"></rect>
-    <rect width="285" height="3"></rect>
-    <rect width="285" height="3" transform="translate(0 97)"></rect>
+    <rect width="3" height="100"/>
+    <rect width="3" height="100" transform="translate(282 0)"/>
+    <rect width="285" height="3"/>
+    <rect width="285" height="3" transform="translate(0 97)"/>
   </g>
   <use xlink:href="{Binding icon, Converter=orgChartConverters.addHashConverter}" transform="scale(0.75) translate(15 30)"/>
-  <text transform="translate(75 40)" data-content="{Binding name, Converter=orgChartConverters.intermediateConverter}" style="font-size:26px; font-family:Roboto,sans-serif; fill:#336699;"></text>
-  <text transform="translate(75 70)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=true}" style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"></text>
-  <text transform="translate(75 90)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=false}" style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"></text>
+  <text transform="translate(75 40)" data-content="{Binding name, Converter=orgChartConverters.intermediateConverter}" style="font-size:26px; font-family:Roboto,sans-serif; fill:#336699;"/>
+  <text transform="translate(75 70)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=true}" style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"/>
+  <text transform="translate(75 90)" data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=false}" style="font-size:15px; font-family:Roboto,sans-serif; text-transform: uppercase; font-weight: 400"/>
 </g>
 <g id="overviewNodeStyleTemplate">
   <rect fill="#AAA" width="288" height="103" transform="translate(-1 -1)"/>
   <rect fill="#FFFFFF" width="285" height="100"/>
   <use xlink:href="{Binding status, Converter=orgChartConverters.addHashConverter}"/>
   <g class="hoverable">
-    <rect width="3" height="100"></rect>
-    <rect width="3" height="100" transform="translate(282 0)"></rect>
-    <rect width="285" height="3"></rect>
-    <rect width="285" height="3" transform="translate(0 97)"></rect>
+    <rect width="3" height="100"/>
+    <rect width="3" height="100" transform="translate(282 0)"/>
+    <rect width="285" height="3"/>
+    <rect width="285" height="3" transform="translate(0 97)"/>
   </g>
   <text transform="translate(30 50)" data-content="{Binding name, Converter=orgChartConverters.overviewConverter}"
-      style="font-size:40px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"></text>
+      style="font-size:40px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"/>
 </g>
 
 
@@ -136,7 +136,7 @@
 <!-- and can be referenced in the templates. In this case, this happens via converters.           -->
 
   <g id="PortStyleTemplate">
-    <use xlink:href="{TemplateBinding styleTag, Converter=orgChartDemo.iconConverter}" style="pointer-events:none"></use>
+    <use xlink:href="{TemplateBinding styleTag, Converter=orgChartDemo.iconConverter}" style="pointer-events:none"/>
   </g>
 </script>
 

--- a/demos/databinding/simplegraphbuilder/index.html
+++ b/demos/databinding/simplegraphbuilder/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Simple Graph Builder Demo [yFiles for HTML]</title>
@@ -44,16 +44,16 @@
   <script type="text/yfiles-template">
     <defs>
       <clipPath id="myClip">
-        <rect width="260" height="60"></rect>
+        <rect width="260" height="60"/>
       </clipPath>
     </defs>
     <g id="nodeTemplate" clip-path="url(#myClip)">
       <rect fill="#FF8C00" stroke="#FFF" stroke-width="1" rx="2" ry="2"
-          width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+          width="{TemplateBinding width}" height="{TemplateBinding height}"/>
       <text transform="translate(10 20)" data-content="{Binding name}"
-          style="font-size:18px; fill:#000; text-anchor: start; dominant-baseline: central;"></text>
+          style="font-size:18px; fill:#000; text-anchor: start; dominant-baseline: central;"/>
       <text transform="translate(10 40)" data-content="{Binding position}"
-          style="font-size:18px; fill:#000; text-anchor: start; dominant-baseline: central;"></text>
+          style="font-size:18px; fill:#000; text-anchor: start; dominant-baseline: central;"/>
     </g>
   </script>
 

--- a/demos/layout/layerconstraints/index.html
+++ b/demos/layout/layerconstraints/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Layer Constraints Demo [yFiles for HTML]</title>
@@ -62,36 +62,36 @@
     <g id="ConstraintNodeStyle">
       <g visibility="{Binding constraints, Converter=layerconstraintsdemo.constraintsvisibilityconverter}">
         <rect stroke="none" fill="{Binding value, Converter=layerconstraintsdemo.backgroundconverter}" rx="4" ry="4"
-            width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+            width="{TemplateBinding width}" height="{TemplateBinding height}"/>
         <text data-content="{Binding value, Converter=layerconstraintsdemo.constraintconverter}" x="30" y="22"
             text-anchor="middle" font-size="22"
-            fill="{Binding value, Converter=layerconstraintsdemo.textcolorconverter}"></text>
+            fill="{Binding value, Converter=layerconstraintsdemo.textcolorconverter}"/>
         <g transform="translate(0 50)" class="button-container">
-          <ellipse cx="12" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <path d="M 7 -12 L 17 -12" stroke="grey" stroke-width="2"></path>
+          <ellipse cx="12" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <path d="M 7 -12 L 17 -12" stroke="grey" stroke-width="2"/>
         </g>
         <g transform="translate(0 50)" class="button-container">
-          <ellipse cx="30" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <ellipse cx="30" cy="-14" rx="2" ry="3" stroke="grey" fill="none"></ellipse>
-          <rect width="9" height="7" rx="1" ry="1" x="25.5" y="-14" fill="grey"></rect>
-          <path d="M 30 -11 L 30 -9" stroke="white" stroke-linecap="round" fill="none"></path>
-          <ellipse cx="30" cy="-11" rx="1" ry="1" stroke="none" fill="white"></ellipse>
+          <ellipse cx="30" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <ellipse cx="30" cy="-14" rx="2" ry="3" stroke="grey" fill="none"/>
+          <rect width="9" height="7" rx="1" ry="1" x="25.5" y="-14" fill="grey"/>
+          <path d="M 30 -11 L 30 -9" stroke="white" stroke-linecap="round" fill="none"/>
+          <ellipse cx="30" cy="-11" rx="1" ry="1" stroke="none" fill="white"/>
         </g>
         <g transform="translate(0 50)" class="button-container">
-          <ellipse cx="48" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <path d="M 48 -17 L 48 -7 M 43 -12 L 53 -12" stroke="grey" stroke-width="2"></path>
+          <ellipse cx="48" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <path d="M 48 -17 L 48 -7 M 43 -12 L 53 -12" stroke="grey" stroke-width="2"/>
         </g>
       </g>
       <g visibility="{Binding constraints, Converter=layerconstraintsdemo.noconstraintsvisibilityconverter}">
         <rect stroke="none" fill="lightgrey" rx="4" ry="4" width="{TemplateBinding width}"
-            height="{TemplateBinding height}"></rect>
+            height="{TemplateBinding height}"/>
         <g class="button-container">
-          <ellipse cx="30" cy="25" rx="15" ry="15" stroke="none" fill="white" class="button"></ellipse>
-          <ellipse cx="30" cy="21" rx="4" ry="6" stroke="grey" stroke-width="2" fill="none"></ellipse>
-          <rect width="18" height="14" rx="2" ry="2" x="21" y="20" fill="grey"></rect>
-          <path d="M 30 25 L 30 30" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"></path>
-          <ellipse cx="30" cy="25" rx="2" ry="2" stroke="none" fill="white"></ellipse>
-          <path d="M 30 20 L 36 11 L 36 20 Z" stroke="none" fill="white"></path>
+          <ellipse cx="30" cy="25" rx="15" ry="15" stroke="none" fill="white" class="button"/>
+          <ellipse cx="30" cy="21" rx="4" ry="6" stroke="grey" stroke-width="2" fill="none"/>
+          <rect width="18" height="14" rx="2" ry="2" x="21" y="20" fill="grey"/>
+          <path d="M 30 25 L 30 30" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <ellipse cx="30" cy="25" rx="2" ry="2" stroke="none" fill="white"/>
+          <path d="M 30 20 L 36 11 L 36 20 Z" stroke="none" fill="white"/>
         </g>
       </g>
     </g>

--- a/demos/layout/multipage/index.html
+++ b/demos/layout/multipage/index.html
@@ -32,7 +32,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Multi-Page Layout Demo [yFiles for HTML]</title>
@@ -45,40 +45,40 @@
   <script type="text/yfiles-template">
     <g id="NormalNodeTemplate">
       <rect fill="#99CCFF" stroke="#99CCFF" stroke-width="1" rx="2" ry="2" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <text data-content="{TemplateBinding item, Converter=multipage.labelconverter}"
           transform="{TemplateBinding width, Converter=multipage.transformconverter}"
-          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"></text>
+          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"/>
     </g>
     <g id="ConnectorNodeTemplate">
       <rect fill="#FF8C00" stroke="#FF8C00" stroke-width="2" rx="2" ry="2" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <rect fill="white" rx="2" ry="2" class="hoverable" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <text data-content="{TemplateBinding item, Converter=multipage.labelconverter}"
           transform="{TemplateBinding width, Converter=multipage.transformconverter}"
-          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"></text>
-      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"/>
+      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"/>
     </g>
     <g id="ProxyNodeTemplate">
       <rect fill="#99CC33" stroke="#99CC33" stroke-width="2" rx="2" ry="2" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <rect fill="white" rx="2" ry="2" class="hoverable" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <text data-content="{TemplateBinding item, Converter=multipage.labelconverter}"
           transform="{TemplateBinding width, Converter=multipage.transformconverter}"
-          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"></text>
-      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"/>
+      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"/>
     </g>
     <g id="ProxyReferenceNodeTemplate">
       <rect fill="#F23802" stroke="#F23802" stroke-width="2" rx="2" ry="2" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <rect fill="white" rx="2" ry="2" class="hoverable" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
+          height="{TemplateBinding height}"/>
       <text data-content="{TemplateBinding item, Converter=multipage.labelconverter}"
           transform="{TemplateBinding width, Converter=multipage.transformconverter}"
-          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"></text>
-      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+          style="font-size:10px; font-family:Arial; fill:#000; text-anchor: middle; dominant-baseline: central;"/>
+      <rect rx="2" ry="2" style="opacity: 0" width="{TemplateBinding width}" height="{TemplateBinding height}"/>
     </g>
   </script>
   <style type="text/css">

--- a/demos/layout/sequenceconstraints/index.html
+++ b/demos/layout/sequenceconstraints/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Sequence Constraints Demo [yFiles for HTML]</title>
@@ -57,36 +57,36 @@
     <g id="ConstraintNodeStyle">
       <g visibility="{Binding constraints, Converter=sequenceconstraintsdemo.constraintsvisibilityconverter}">
         <rect stroke="none" fill="{Binding value, Converter=sequenceconstraintsdemo.backgroundconverter}" rx="4" ry="4"
-            width="{TemplateBinding width}" height="{TemplateBinding height}"></rect>
+            width="{TemplateBinding width}" height="{TemplateBinding height}"/>
         <text data-content="{Binding value, Converter=sequenceconstraintsdemo.constraintconverter}" x="30" y="22"
             text-anchor="middle" font-size="22"
-            fill="{Binding value, Converter=sequenceconstraintsdemo.textcolorconverter}"></text>
+            fill="{Binding value, Converter=sequenceconstraintsdemo.textcolorconverter}"/>
         <g transform="translate(0 50)">
-          <ellipse cx="12" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <path d="M 7 -12 L 17 -12" stroke="grey" stroke-width="2"></path>
+          <ellipse cx="12" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <path d="M 7 -12 L 17 -12" stroke="grey" stroke-width="2"/>
         </g>
         <g transform="translate(0 50)">
-          <ellipse cx="30" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <ellipse cx="30" cy="-14" rx="2" ry="3" stroke="grey" fill="none"></ellipse>
-          <rect width="9" height="7" rx="1" ry="1" x="25.5" y="-14" fill="grey"></rect>
-          <path d="M 30 -11 L 30 -9" stroke="white" stroke-linecap="round" fill="none"></path>
-          <ellipse cx="30" cy="-11" rx="1" ry="1" stroke="none" fill="white"></ellipse>
+          <ellipse cx="30" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <ellipse cx="30" cy="-14" rx="2" ry="3" stroke="grey" fill="none"/>
+          <rect width="9" height="7" rx="1" ry="1" x="25.5" y="-14" fill="grey"/>
+          <path d="M 30 -11 L 30 -9" stroke="white" stroke-linecap="round" fill="none"/>
+          <ellipse cx="30" cy="-11" rx="1" ry="1" stroke="none" fill="white"/>
         </g>
         <g transform="translate(0 50)">
-          <ellipse cx="48" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"></ellipse>
-          <path d="M 48 -17 L 48 -7 M 43 -12 L 53 -12" stroke="grey" stroke-width="2"></path>
+          <ellipse cx="48" cy="-12" rx="8" ry="8" stroke="none" fill="white" class="button"/>
+          <path d="M 48 -17 L 48 -7 M 43 -12 L 53 -12" stroke="grey" stroke-width="2"/>
         </g>
       </g>
       <g visibility="{Binding constraints, Converter=sequenceconstraintsdemo.noconstraintsvisibilityconverter}">
         <rect stroke="none" fill="lightgrey" rx="4" ry="4" width="{TemplateBinding width}"
-            height="{TemplateBinding height}"></rect>
+            height="{TemplateBinding height}"/>
         <g>
-          <ellipse cx="30" cy="25" rx="15" ry="15" stroke="none" fill="white" class="button"></ellipse>
-          <ellipse cx="30" cy="21" rx="4" ry="6" stroke="grey" stroke-width="2" fill="none"></ellipse>
-          <rect width="18" height="14" rx="2" ry="2" x="21" y="20" fill="grey"></rect>
-          <path d="M 30 25 L 30 30" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"></path>
-          <ellipse cx="30" cy="25" rx="2" ry="2" stroke="none" fill="white"></ellipse>
-          <path d="M 30 20 L 36 11 L 36 20 Z" stroke="none" fill="white"></path>
+          <ellipse cx="30" cy="25" rx="15" ry="15" stroke="none" fill="white" class="button"/>
+          <ellipse cx="30" cy="21" rx="4" ry="6" stroke="grey" stroke-width="2" fill="none"/>
+          <rect width="18" height="14" rx="2" ry="2" x="21" y="20" fill="grey"/>
+          <path d="M 30 25 L 30 30" stroke="white" stroke-width="2" stroke-linecap="round" fill="none"/>
+          <ellipse cx="30" cy="25" rx="2" ry="2" stroke="none" fill="white"/>
+          <path d="M 30 20 L 36 11 L 36 20 Z" stroke="none" fill="white"/>
         </g>
       </g>
     </g>

--- a/demos/style/templatestyles/index.html
+++ b/demos/style/templatestyles/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Template Styles Demo [yFiles for HTML]</title>
@@ -47,12 +47,12 @@
 
     <!-- A very basic template for ports that consists of an ellipse -->
     <ellipse id="orgchart-port-template" fill="rgb(229,233,240)" cx="0" cy="0"
-             rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"></ellipse>
+             rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"/>
 
     <!-- A template for labels renders the label text with an outline stroke -->
     <g id="orgchart-label-template" class="orgchart-label">
-      <text data-content="{TemplateBinding labelText}" dy="1em" stroke="rgb(94,103,130)" stroke-width="7px" stroke-linejoin="round" text-anchor="middle" transform="translate(50 0)"></text>
-      <text data-content="{TemplateBinding labelText}" dy="1em" fill="rgb(229,233,240)" text-anchor="middle" transform="translate(50 0)"></text>
+      <text data-content="{TemplateBinding labelText}" dy="1em" stroke="rgb(94,103,130)" stroke-width="7px" stroke-linejoin="round" text-anchor="middle" transform="translate(50 0)"/>
+      <text data-content="{TemplateBinding labelText}" dy="1em" fill="rgb(229,233,240)" text-anchor="middle" transform="translate(50 0)"/>
     </g>
 
     <!-- A template for nodes that renders the icon and name as well as a status indicator and selection visualization -->
@@ -61,40 +61,40 @@
       <defs>
         <clipPath id="imageClip">
           <ellipse cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"
-            rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5-5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5-5}"></ellipse>
+            rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5-5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5-5}"/>
         </clipPath>
         <clipPath id="labelClip">
           <rect x="0" y="{TemplateBinding height, Converter=calc, Parameter=$v*0.6}"
-          width="{TemplateBinding width}" height="{TemplateBinding height, Converter=calc, Parameter=$v*0.4}"></rect>
+          width="{TemplateBinding width}" height="{TemplateBinding height, Converter=calc, Parameter=$v*0.4}"/>
         </clipPath>
       </defs>
       <!-- An ellipse that appears on hover via CSS -->
       <ellipse class="hover-ellipse" fill="{Binding businessUnit, Converter=backgroundColor}"
                cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"
-               rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5+10}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5+10}"></ellipse>
+               rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5+10}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5+10}"/>
       <!-- The background ellipse -->
       <ellipse fill="{Binding businessUnit, Converter=backgroundColor}"
         cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"
-        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"></ellipse>
+        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"/>
       <!-- The user icon -->
       <image xlink:href="{Binding icon, Converter=icon}" clip-path="url(#imageClip)"
         x="5" y="{TemplateBinding height, Converter=calc, Parameter=$v*-0.1}"
-        width="{TemplateBinding width, Converter=calc, Parameter=$v-10}" height="{TemplateBinding height, Converter=calc, Parameter=$v-10}"></image>
+        width="{TemplateBinding width, Converter=calc, Parameter=$v-10}" height="{TemplateBinding height, Converter=calc, Parameter=$v-10}"/>
       <!-- The half-circle background for the name -->
       <ellipse  fill="{Binding businessUnit, Converter=backgroundColor}" clip-path="url(#labelClip)"
         cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"
-        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"></ellipse>
+        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"/>
       <!-- The name text -->
       <text fill="rgb(37,41,52)" data-content="{Binding name}" text-anchor="middle" style="font-family: Tahoma, Verdana, sans-serif" font-size="{TemplateBinding width, Converter=fontSize}"
-        x="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" y="{TemplateBinding height, Converter=calc, Parameter=$v*0.75}"></text>
+        x="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" y="{TemplateBinding height, Converter=calc, Parameter=$v*0.75}"/>
       <!-- The focus indicator -->
       <ellipse stroke="rgb(255,220,0)" fill="none" stroke-width="10" visibility="{TemplateBinding itemFocused, Converter=visibility}"
         cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.5}"
-        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5+5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5+5}"></ellipse>
+        rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.5+5}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.5+5}"/>
       <!-- The status indicator -->
       <ellipse fill="{Binding status, Converter=statusColor}" class="orgchart-status-indicator"
                cx="{TemplateBinding width, Converter=calc, Parameter=$v*0.90-5}" cy="{TemplateBinding height, Converter=calc, Parameter=$v*0.1+5}"
-               rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.10}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.10}"></ellipse>
+               rx="{TemplateBinding width, Converter=calc, Parameter=$v*0.10}" ry="{TemplateBinding height, Converter=calc, Parameter=$v*0.10}"/>
     </g>
   </script>
 

--- a/demos/view/clipboard/index.html
+++ b/demos/view/clipboard/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title>Clipboard Demo [yFiles for HTML]</title>
@@ -50,11 +50,11 @@
         </linearGradient>
       </defs>
       <rect stroke="none" fill="url(#innerGradient)" rx="4" ry="4" width="{TemplateBinding width}"
-          height="{TemplateBinding height}"></rect>
-      <rect stroke="none" fill="white" fill-opacity="0.25" width="{TemplateBinding width}" height="30"></rect>
+          height="{TemplateBinding height}"/>
+      <rect stroke="none" fill="white" fill-opacity="0.25" width="{TemplateBinding width}" height="30"/>
       <text data-content="{Binding name}"
           transform="{TemplateBinding width, Converter=centertransformconverter, Parameter=15}"
-          text-anchor="middle" style="font-size:120%; fill:#000" dy="0.5em"></text>
+          text-anchor="middle" style="font-size:120%; fill:#000" dy="0.5em"/>
     </g>
   </script>
 

--- a/demos/view/overviewstyles/index.html
+++ b/demos/view/overviewstyles/index.html
@@ -31,7 +31,7 @@
      // LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
      // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
      // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     // 
+     //
      ////////////////////////////////////////////////////////////////////////-->
 
   <title id="title">Overview Styling Demo [yFiles for HTML]</title>
@@ -73,26 +73,26 @@
       <use xlink:href="{Binding status, Converter=orgChartConverters.addHashConverter, Parameter=_icon}"
         transform="translate(26 84)"/>
       <g style="font-size:10px; font-family:Roboto,sans-serif; font-weight: 300; fill: #444">
-        <text transform="translate(100 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"></text>
+        <text transform="translate(100 25)" data-content="{Binding name}" style="font-size:16px; fill:#336699"/>
         <text transform="translate(100 45)"
           data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=true}"
-          style="text-transform: uppercase; font-weight: 400"></text>
+          style="text-transform: uppercase; font-weight: 400"/>
         <text transform="translate(100 57)"
           data-content="{Binding position, Converter=orgChartConverters.lineBreakConverter, Parameter=false}"
-          style="text-transform: uppercase; font-weight: 400"></text>
-        <text transform="translate(100 72)" data-content="{Binding email}"></text>
-        <text transform="translate(100 88)" data-content="{Binding phone}"></text>
-        <text transform="translate(170 88)" data-content="{Binding fax}"></text>
+          style="text-transform: uppercase; font-weight: 400"/>
+        <text transform="translate(100 72)" data-content="{Binding email}"/>
+        <text transform="translate(100 88)" data-content="{Binding phone}"/>
+        <text transform="translate(170 88)" data-content="{Binding fax}"/>
       </g>
     </g>
 
     <g id="overViewNodeStyle">
       <rect fill="{Binding status, Converter=orgChartConverters.colorConverter}" width="30"
-        height="{TemplateBinding height}"></rect>
+        height="{TemplateBinding height}"/>
       <rect fill="white" transform="translate(30 0)" width="{TemplateBinding width}" height="{TemplateBinding height}"
-        rx="10" ry="10"></rect>
+        rx="10" ry="10"/>
       <text transform="translate(50 50)" data-content="{Binding name, Converter=orgChartConverters.overviewConverter}"
-        style="font-size:50px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"></text>
+        style="font-size:50px; font-family:Roboto,sans-serif; fill:#336699; dominant-baseline: central;"/>
     </g>
 
   </script>


### PR DESCRIPTION
For valid template syntax highlight (as SVG, but not as HTML)  [related IDEA plugin](https://plugins.jetbrains.com/plugin/13384-yfiles/) can be used

### Before
![image](https://user-images.githubusercontent.com/9942723/92328308-9da01300-f068-11ea-9f86-3a4d2f512da8.png)

### After
![image](https://user-images.githubusercontent.com/9942723/92328302-8b25d980-f068-11ea-8745-268104164b90.png)